### PR TITLE
add support for exstensionless files import

### DIFF
--- a/hyper_click/less_path_resolver.py
+++ b/hyper_click/less_path_resolver.py
@@ -17,4 +17,10 @@ class LessPathResolver:
         if path.isfile(file_path):
             return file_path
 
+        combined = path.realpath(path.join(self.current_dir, self.str_path))
+        # matching ../variables/palette to ../variables/palette.less
+        for ext in self.valid_extensions:
+            file_path = combined + '.' + ext
+            if path.isfile(file_path):
+                return file_path
         return ''


### PR DESCRIPTION
i see that less accept extensionless file import even if it's not explicity express on the documentation