### PR TITLE
fix new open file not working right click

### DIFF
--- a/hyper_click_command.py
+++ b/hyper_click_command.py
@@ -18,6 +18,7 @@ class HyperClickJumpCommand(sublime_plugin.TextCommand):
         self.lang = self.get_lang(self.syntax)
 
     def run(self, edit):
+        self.window = self.view.window()
         v = self.view
 
         if len(v.sel()) != 1:


### PR DESCRIPTION
I see that when you open a new file from the quick panel, the self.window element remains undefined.
I add a refresh on the command similar to what is done in annotate() in annotator.py