### PR TITLE
Add support for HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ falls short for most languages since jumping between these required files needs
 some knowledge about how the language or package manager of the language is working.
 
 HyperClick tries to solve this issue. Currently, it knows how to jump between files
-in **Javascript**, **Sass**, **Less**, **Stylus** and **PHP**  but can be easily 
+in **Javascript**, **Sass**, **Less**, **Stylus**, **PHP**, **HTML (imports)**  but can be easily
 extended to support more languages.
 
 ## Supported Languages and Syntaxes
@@ -23,6 +23,7 @@ extended to support more languages.
 | Less       | `LESS.tmLanguage`                        |
 | Stylus     | `Stylus.tmLanguage`                      |
 | PHP        | `PHP.sublime-syntax` <br> `PHP Source.sublime-syntax`  |
+| HTML       | `HTML.sublime-syntax` |
 
 *You can contribute and add more languages by adding a path resolver like [SassPathResolver](https://github.com/aziz/SublimeHyperClick/blob/master/hyper_click/sass_path_resolver.py)*
 
@@ -101,27 +102,60 @@ see [hyper_click.sublime-settings](https://github.com/aziz/SublimeHyperClick/blo
     "sass": [
       "SCSS.tmLanguage",
       "Sass.tmLanguage"
+    ],
+    "less": [
+      "LESS.tmLanguage"
+    ],
+    "php": [
+      "PHP.sublime-syntax",
+      "PHP Source.sublime-syntax"
+    ],
+    "stylus": [
+      "Stylus.tmLanguage"
+    ],
+    "html": [
+      "HTML.sublime-syntax"
     ]
   },
   "import_line_regex": {
     "js": [
-      "^import\\s+.+\\s+from\\s+['\"](.+)['\"];?$",
       "^import\\s+['\"](.+)['\"];?$",
-      ".+require\\(['\"](.+)['\"]\\).+"
+      ".*from\\s+['\"](.+)['\"];?$",
+      ".*require\\(['\"](.+?)['\"]\\).*"
     ],
     "sass": [
       "^@import\\s+['\"](.+)['\"];?$"
+    ],
+    "less": [
+      "^@import\\s+\\(?.*\\)?\\s*['\"](.+)['\"];?$"
+    ],
+    "php": [
+      "^import\\(['\"](.+)['\"]\\);?$",
+      "^import_once\\(['\"](.+)['\"]\\);?$",
+      "^require\\(['\"](.+)['\"]\\);?$",
+      "^require_once\\(['\"](.+)['\"]\\);?$"
+    ],
+    "stylus": [
+      "^@import\\s+['\"](.+)['\"];?$"
+    ],
+    "html": [
+      ".*?<link\\s+rel=\"import\"\\s+href=['\"](.+)['\"]/?>.*?"
     ]
   },
   "valid_extensions": {
     "js": ["js", "jsx"],
-    "sass": ["scss", "sass"]
+    "sass": ["scss", "sass"],
+    "less": ["less"],
+    "php": ["php"],
+    "stylus": ["styl", "stylus"],
+    "html": ["html"]
   },
   "default_filenames": {
     "js": ["index"]
   },
   "vendor_dirs": {
-    "js": ["node_modules"]
+    "js": ["node_modules"],
+    "html": ["node_modules", "bower_components"]
   },
   "annotation_found_text": "➜",
   "annotation_not_found_text": "✘",

--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -19,6 +19,9 @@
     ],
     "stylus": [
       "Stylus.tmLanguage"
+    ],
+    "html": [
+      "HTML.sublime-syntax"
     ]
   },
   "import_line_regex": {
@@ -41,6 +44,9 @@
     ],
     "stylus": [
       "^@import\\s+['\"](.+)['\"];?$"
+    ],
+    "html": [
+      ".*?<link\\s+rel=\"import\"\\s+href=['\"](.+)['\"]/?>.*?"
     ]
   },
   "valid_extensions": {
@@ -48,13 +54,15 @@
     "sass": ["scss", "sass"],
     "less": ["less"],
     "php": ["php"],
-    "stylus": ["styl", "stylus"]
+    "stylus": ["styl", "stylus"],
+    "html": ["html"]
   },
   "default_filenames": {
     "js": ["index"]
   },
   "vendor_dirs": {
-    "js": ["node_modules"]
+    "js": ["node_modules"],
+    "html": ["node_modules", "bower_components"]
   },
   "annotation_found_text": "➜",
   "annotation_not_found_text": "✘",

--- a/hyper_click/html_path_resolver.py
+++ b/hyper_click/html_path_resolver.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from os import path
+
+
+# A default resolver that resolves to a subfolder along along with one of the valid extensions
+class HTMLPathResolver:
+    def __init__(self, str_path, current_dir, roots, lang, settings):
+        self.str_path = str_path
+        self.current_dir = current_dir
+        self.lang = lang
+        self.settings = settings
+        self.roots = roots
+        self.valid_extensions = settings.get('valid_extensions', {})[lang]
+
+    def resolve(self):
+        combined = path.realpath(path.join(self.current_dir, self.str_path))
+
+        # Loop all allowed extensions, and try matching those
+        for ext in self.valid_extensions:
+            file_path = combined
+            if path.isfile(file_path):
+                return file_path
+        return ''

--- a/hyper_click/path_resolver.py
+++ b/hyper_click/path_resolver.py
@@ -4,6 +4,7 @@ from .js_path_resolver import JsPathResolver
 from .sass_path_resolver import SassPathResolver
 from .less_path_resolver import LessPathResolver
 from .php_path_resolver import PhpPathResolver
+from .html_path_resolver import HTMLPathResolver
 from .path_generic_subfolder_resolver import GenericSubfolderResolver
 
 
@@ -18,6 +19,8 @@ class HyperClickPathResolver:
             self.resolver = LessPathResolver(str_path, current_dir, roots, lang, settings)
         elif lang == 'php':
             self.resolver = PhpPathResolver(str_path, current_dir, roots, lang, settings)
+        elif lang == 'html':
+            self.resolver = HTMLPathResolver(str_path, current_dir, roots, lang, settings)
         else:
             self.resolver = GenericSubfolderResolver(str_path, current_dir, roots, lang, settings)
 


### PR DESCRIPTION
This PR adds support for HTML imports, namely \<link rel="import" href="..."/\>

Things that can be improved in the future:
- add support for other types of links inside HTML: 
with src attribute (list of tags to support https://www.w3schools.com/tags/att_src.asp) or with href attribute.
- improve regular expression so that it matches any order of [rel=import] and [href] attributes
