### PR TITLE
js: allow search vendor in root directory

### DIFF
--- a/hyper_click/js_path_resolver.py
+++ b/hyper_click/js_path_resolver.py
@@ -33,7 +33,7 @@ class JsPathResolver:
             while found_path is None and current_root:
                 pruned = False
                 for root, dirs, files in walk(current_root):
-                    if not pruned:
+                    if not pruned and not vendor in dirs:
                        try:
                           # R'.emove the part of the tree we already searched
                           del dirs[dirs.index(path.basename(last_root))]


### PR DESCRIPTION
Hi!

I configured `vendor_dirs` as `["src", "node_modules"]`, but `src` did not found in root of the project because it was removed from `dirs` of current root.

So this patch fixes this issue

