### PR TITLE
JS resolving refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,9 @@ see [hyper_click.sublime-settings](https://github.com/aziz/SublimeHyperClick/blo
   "vendor_dirs": {
     "js": ["node_modules"]
   },
+  "lookup_paths": {
+    "js": []
+  },
   "annotation_found_text": "➜",
   "annotation_not_found_text": "✘",
   "annotations_enabled": true

--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -56,6 +56,9 @@
   "vendor_dirs": {
     "js": ["node_modules"]
   },
+  "lookup_paths": {
+    "js": []
+  },
   "annotation_found_text": "➜",
   "annotation_not_found_text": "✘",
   "annotations_enabled": true

--- a/hyper_click/js_path_resolver.py
+++ b/hyper_click/js_path_resolver.py
@@ -20,37 +20,8 @@ class JsPathResolver:
         self.roots = roots
         self.valid_extensions = settings.get('valid_extensions', {})[lang]
         self.default_filenames = settings.get('default_filenames', {})[lang]
-        self.vendors = settings.get('vendor_dirs', {})[lang]
-        self.vendor_dirs = [];
+        self.vendor_dirs = settings.get('vendor_dirs', {})[lang];
         self.matchingRoot = [root for root in self.roots if self.current_dir.startswith(root)]
-
-        start_path = self.current_dir
-        for vendor in self.vendors:
-            last_root    = start_path
-            current_root = start_path
-            found_path = None
-
-            while found_path is None and current_root:
-                pruned = False
-                for root, dirs, files in walk(current_root):
-                    if not pruned and not vendor in dirs:
-                       try:
-                          # R'.emove the part of the tree we already searched
-                          del dirs[dirs.index(path.basename(last_root))]
-                          pruned = True
-                       except ValueError:
-                          pass
-                    if vendor in dirs:
-                       # found the vendor direcotry, stop
-                       found_path = path.join(root, vendor)
-                       self.vendor_dirs.append(found_path)
-                       break
-                # Otherwise, pop up a level, search again
-                last_root    = current_root
-                try:
-                    current_root = [path.dirname(last_root) for root in self.roots if path.dirname(last_root).startswith(root)][0]
-                except IndexError:
-                    current_root = None
 
 
     def resolve(self):

--- a/hyper_click/js_path_resolver.py
+++ b/hyper_click/js_path_resolver.py
@@ -1,15 +1,40 @@
 # -*- coding: utf-8 -*-
 import json
 from os import path, walk
+from bisect import bisect_left
 
-NODE_CORE_MODULES = ["assert", "buffer", "child_process", "cluster", "console", "constants",
+NODE_CORE_MODULES = sorted(["assert", "buffer", "child_process", "cluster", "console", "constants",
                      "crypto", "dgram", "dns", "domain", "events", "fs", "http", "https",
                      "module", "net", "os", "path", "process", "punycode", "querystring",
                      "readline", "repl", "stream", "string_decoder", "sys", "timers", "tls",
-                     "tty", "url", "util", "v8", "vm", "zlib"]
+                     "tty", "url", "util", "v8", "vm", "zlib"])
 
 NODE_CORE_MODULES_TEMPLATE = "https://github.com/nodejs/node/blob/master/lib/{}.js"
 
+def find_index(a, x):
+    'Locate the leftmost value exactly equal to x'
+    i = bisect_left(a, x)
+    if i != len(a) and a[i] == x:
+        return i
+    return -1
+
+def walkup_dir(start_path, vendor_dirs, endpath = '/'):
+    current_dir = start_path
+    target = current_dir
+    while True:
+        for dirname in vendor_dirs:
+            target = path.join(current_dir, dirname)
+            if path.isdir(target):
+                yield target
+            if current_dir == endpath:
+                return
+            # go up
+            parent_dir = path.dirname(current_dir)
+            if len(parent_dir) == len(current_dir):
+                return
+            current_dir = parent_dir
+
+# doc: https://nodejs.org/dist/latest-v8.x/docs/api/modules.html#modules_all_together
 
 class JsPathResolver:
     def __init__(self, str_path, current_dir, roots, lang, settings):
@@ -19,93 +44,78 @@ class JsPathResolver:
         self.settings = settings
         self.roots = roots
         self.valid_extensions = settings.get('valid_extensions', {})[lang]
-        self.default_filenames = settings.get('default_filenames', {})[lang]
         self.vendor_dirs = settings.get('vendor_dirs', {})[lang];
         self.matchingRoot = [root for root in self.roots if self.current_dir.startswith(root)]
-
+        self.currentRoot = self.matchingRoot[0]
 
     def resolve(self):
-        if self.str_path.startswith('.'):
-            return self.resolve_relative_path()
-        else:
-            if '/' in self.str_path and not self.str_path.startswith('@'):
-                return self.resolve_package_internal_path()
-            else:
-                return self.resolve_package_root_path()
+        if find_index(NODE_CORE_MODULES, self.str_path) != -1:
+            return NODE_CORE_MODULES_TEMPLATE.format(self.str_path)
 
-    def resolve_relative_path(self):
-        combined = path.realpath(path.join(self.current_dir, self.str_path))
+        context_dir = self.current_dir
+        if self.str_path.startswith('/'):
+            context_dir = '/'
 
-        if path.isfile(combined):
-            return combined
+        if self.str_path.startswith('./') or self.str_path.startswith('../') or context_dir == '/':
+            result = self.resolve_relative_to_dir(self.str_path, context_dir)
+            if result:
+                return result
 
+        result = self.resolve_in_lookup_paths(self.str_path)
+        if result:
+            return result
+        return self.resolve_node_modules(self.str_path, self.current_dir)
+
+    def resolve_relative_to_dir(self, target, directory):
+        combined = path.realpath(path.join(directory, target))
+        return self.resolve_as_file(combined) or self.resolve_as_directory(combined)
+
+    def resolve_node_modules(self, target, start_dir):
+        for vendor_path in walkup_dir(start_dir, self.vendor_dirs, self.currentRoot):
+            lookup_path = path.join(vendor_path, target)
+            result = self.resolve_as_file(lookup_path)
+            if result:
+                return result
+            result = self.resolve_as_directory(lookup_path)
+            if result:
+                return result
+
+    def resolve_in_lookup_paths(self, target):
+        lookup_paths = self.settings.get('lookup_paths', {})[self.lang] or []
+        for lookup_path in lookup_paths:
+            result = self.resolve_relative_to_dir(target, path.join(self.currentRoot, lookup_path))
+            if result:
+                return result
+
+
+    def resolve_as_file(self, path_name):
+        if path.isfile(path_name):
+            return path_name
         # matching ../index to /index.js
         for ext in self.valid_extensions:
-            file_path = combined + '.' + ext
+            file_path = path_name + '.' + ext
             if path.isfile(file_path):
                 return file_path
 
+    def resolve_index(self, dirname):
         # matching ./demo to /demo/index.js
-        if path.isdir(combined):
-            for default_name in self.default_filenames:
-                for ext in self.valid_extensions:
-                    file_path = path.join(combined, default_name + '.' + ext)
-                    if path.isfile(file_path):
-                        return file_path
-        return ''
+        if path.isdir(dirname):
+            return self.resolve_as_file(path.join(dirname, 'index'))
 
-    def resolve_package_root_path(self):
-        for root in self.matchingRoot:
-            for vendor_dir in self.vendor_dirs:
-                combined = path.realpath(path.join(root, vendor_dir, self.str_path))
-                package_json_path = path.join(combined, 'package.json')
-                if path.isdir(combined) and path.isfile(package_json_path):
-                    with open(package_json_path, 'r', encoding='utf-8') as data_file:
-                        data = json.load(data_file)
-                    main_file = data.get('main', None)
-                    if main_file:
-                        dest = path.realpath(path.join(combined, data['main']))
-                        if path.isfile(dest):
-                            return path.realpath(path.join(combined, data['main']))
-                        else:
-                            for ext in self.valid_extensions:
-                                if path.isfile(dest + '.' + ext):
-                                    return dest + '.' + ext
-                            for default_name in self.default_filenames:
-                                for ext in self.valid_extensions:
-                                    file_path = path.join(dest, default_name + '.' + ext)
-                                    if path.isfile(file_path):
-                                        return file_path
-                    else:
-                        for default_name in self.default_filenames:
-                            for ext in self.valid_extensions:
-                                file_path = path.join(combined, default_name + '.' + ext)
-                                if path.isfile(file_path):
-                                    return file_path
+    def resolve_as_directory(self, dirname):
+        package_json_path = path.join(dirname, 'package.json')
+        if path.isdir(dirname) and path.isfile(package_json_path):
+            with open(package_json_path, 'r', encoding='utf-8') as data_file:
+                data = json.load(data_file)
+            main_file = data.get('main', None)
+            if main_file:
+                dest = path.realpath(path.join(dirname, data['main']))
+                result = self.resolve_nodepath(dest)
+                if result:
+                    return result
+        return self.resolve_index(dirname)
 
-        # is it a node core module?
-        if self.str_path in NODE_CORE_MODULES:
-            return NODE_CORE_MODULES_TEMPLATE.format(self.str_path)
+    def resolve_nodepath(self, nodepath):
+        return self.resolve_as_file(nodepath) or self.resolve_index(nodepath)
 
-        return ''
 
-    def resolve_package_internal_path(self):
-        for root in self.roots:
-            for vendor_dir in self.vendor_dirs:
-                combined = path.realpath(path.join(root, vendor_dir, self.str_path))
-
-                if path.isfile(combined):
-                    return combined
-
-                for ext in self.valid_extensions:
-                    file_path = combined + '.' + ext
-                    if path.isfile(file_path):
-                        return file_path
-
-                if path.isdir(combined):
-                    for default_name in self.default_filenames:
-                        for ext in self.valid_extensions:
-                            file_path = path.join(combined, default_name + '.' + ext)
-                            if path.isfile(file_path):
-                                return file_path
-        return ''

--- a/hyper_click/js_path_resolver.py
+++ b/hyper_click/js_path_resolver.py
@@ -33,7 +33,7 @@ class JsPathResolver:
             while found_path is None and current_root:
                 pruned = False
                 for root, dirs, files in walk(current_root):
-                    if not pruned:
+                    if not pruned and not vendor in dirs:
                        try:
                           # R'.emove the part of the tree we already searched
                           del dirs[dirs.index(path.basename(last_root))]

--- a/hyper_click_annotator.py
+++ b/hyper_click_annotator.py
@@ -81,7 +81,7 @@ if ST3118:
                 v.erase_phantoms('hyper_click')
                 resolved_path = file_path.resolve()
                 # print('resolved to => ', resolved_path)
-                if len(resolved_path) > 0:
+                if resolved_path:
                     content = """
                         <span class="label label-success"><a href="{link}">{content}</a></span>
                     """.format(

--- a/hyper_click_command.py
+++ b/hyper_click_command.py
@@ -34,7 +34,7 @@ class HyperClickJumpCommand(sublime_plugin.TextCommand):
                 self.roots, self.lang, self.settings
             )
             resolved_path = file_path.resolve()
-            if len(resolved_path) > 0:
+            if resolved_path:
                 if resolved_path.startswith('http://') or resolved_path.startswith('https://'):
                     webbrowser.open_new_tab(resolved_path)
                 else:


### PR DESCRIPTION
changes

1. speed up, now we are walking up the directory chain from current dir searching vendor_dirs only if it's really necessary
2. added setting `lookup_paths` in case if you have NODE_PATH env variable configured in your project
3. resolution algo has been refactored due to achieve better align with official node resolving algo (but it also supports classic algo if we change vendor_dirs to `['.']`)

this PR also fixes issue described in #25 and, partially, #15