### PR TITLE
add jstl language support + refarcoring for multi match regex send to resolver

### DIFF
--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -22,6 +22,9 @@
     ],
     "html": [
       "HTML.sublime-syntax"
+    ],
+    "jstl": [
+      "jstl.tmLanguage"
     ]
   },
   "import_line_regex": {
@@ -47,6 +50,9 @@
     ],
     "html": [
       ".*?<link\\s+rel=\"import\"\\s+href=['\"](.+)['\"]/?>.*?"
+    ],
+    "jstl": [
+      "<([\\w-]*)\\:([\\w-]*)",
     ]
   },
   "valid_extensions": {
@@ -55,17 +61,23 @@
     "less": ["less"],
     "php": ["php"],
     "stylus": ["styl", "stylus"],
-    "html": ["html"]
+    "html": ["html"],
+    "jstl": ["jsp", "tag"]
   },
   "default_filenames": {
     "js": ["index"]
   },
   "vendor_dirs": {
     "js": ["node_modules"],
-    "html": ["node_modules", "bower_components"]
+    "html": ["node_modules", "bower_components"],
+    "jstl": ["WEB-INF"]
   },
   "lookup_paths": {
-    "js": []
+    "js": [],
+    "jstl": [
+      "taglib *prefix ?= ?[\"'](.*)[\"'] *tagdir ?= ?[\"'](.*)[\"']",
+      "xmlns:(\\w*)=[\"']urn:jsptagdir:(.*?)[\"']"
+    ]
   },
   "annotation_found_text": "➜",
   "annotation_not_found_text": "✘",

--- a/hyper_click/jstl_path_resolver.py
+++ b/hyper_click/jstl_path_resolver.py
@@ -1,0 +1,55 @@
+# -*- coding: utf-8 -*-
+import sublime
+import re
+from os import path, walk
+
+
+class JstlPathResolver:
+    def __init__(self, view, str_path, current_dir, roots, lang, settings):
+        self.view = view
+        self.str_path = str_path.group(1)
+        self.str_file = str_path.group(2)
+        self.current_dir = current_dir
+        self.lang = lang
+        self.settings = settings
+        self.roots = roots
+        self.valid_extensions = settings.get('valid_extensions', {})[lang]
+        self.dirs_regex = settings.get('lookup_paths', {})[lang]
+        self.vendors = settings.get('vendor_dirs', {})[lang]
+
+    def resolve(self):
+        for regex_str in self.dirs_regex:
+            regions = self.view.find_all(regex_str)
+            for region in regions:
+                file_path = self.find_folder(region)
+                if file_path:
+                    return file_path
+        return ''
+
+    def find_folder(self, region):
+        text = self.view.substr(region)
+        #print(text)
+        matched = self.is_valid_line(text)
+        #print(matched.group(1))
+        #print(matched.group(2))
+        #print(self.str_path)
+        #print(self.str_file)
+        if matched:
+            if matched.group(1) == self.str_path:
+                complete_path = matched.group(2) + "/" + self.str_file + ".tag"
+                file_path = path.realpath(path.join(self.current_dir, self.str_path))
+                for vendor in self.vendors:
+                    base_dir = re.split(vendor,file_path)
+                    dest_file_path = base_dir[0] + complete_path
+                    #print(dest_file_path)
+                    if path.isfile(dest_file_path):
+                        return dest_file_path
+        return ''
+
+    def is_valid_line(self, line_content):
+        for regex_str in self.dirs_regex:
+            pattern = re.compile(regex_str)
+            matched = pattern.match(line_content)
+            if matched:
+                return matched
+        return False

--- a/hyper_click/path_resolver.py
+++ b/hyper_click/path_resolver.py
@@ -3,26 +3,29 @@ from os import path
 from .js_path_resolver import JsPathResolver
 from .sass_path_resolver import SassPathResolver
 from .less_path_resolver import LessPathResolver
+from .jstl_path_resolver import JstlPathResolver
 from .php_path_resolver import PhpPathResolver
 from .html_path_resolver import HTMLPathResolver
 from .path_generic_subfolder_resolver import GenericSubfolderResolver
 
 
 class HyperClickPathResolver:
-    def __init__(self, str_path, current_file, roots, lang, settings):
+    def __init__(self, view, str_path, current_file, roots, lang, settings):
         current_dir = path.dirname(path.realpath(current_file))
         if lang == 'js':
-            self.resolver = JsPathResolver(str_path, current_dir, roots, lang, settings)
+            self.resolver = JsPathResolver(str_path.group(1), current_dir, roots, lang, settings)
         elif lang == 'sass':
-            self.resolver = SassPathResolver(str_path, current_dir, roots, lang, settings)
+            self.resolver = SassPathResolver(str_path.group(1), current_dir, roots, lang, settings)
         elif lang == 'less':
-            self.resolver = LessPathResolver(str_path, current_dir, roots, lang, settings)
+            self.resolver = LessPathResolver(str_path.group(1), current_dir, roots, lang, settings)
         elif lang == 'php':
-            self.resolver = PhpPathResolver(str_path, current_dir, roots, lang, settings)
+            self.resolver = PhpPathResolver(str_path.group(1), current_dir, roots, lang, settings)
         elif lang == 'html':
-            self.resolver = HTMLPathResolver(str_path, current_dir, roots, lang, settings)
+            self.resolver = HTMLPathResolver(str_path.group(1), current_dir, roots, lang, settings)
+        elif lang == 'jstl':
+            self.resolver = JstlPathResolver(view, str_path, current_dir, roots, lang, settings)
         else:
-            self.resolver = GenericSubfolderResolver(str_path, current_dir, roots, lang, settings)
+            self.resolver = GenericSubfolderResolver(str_path.group(1), current_dir, roots, lang, settings)
 
     def resolve(self):
         return self.resolver.resolve()

--- a/hyper_click_annotator.py
+++ b/hyper_click_annotator.py
@@ -71,9 +71,8 @@ if ST3118:
             matched = self.is_valid_line(line_content)
 
             if matched:
-                destination_str = matched.group(1)
-                file_path = HyperClickPathResolver(
-                    destination_str, v.file_name(),
+                file_path = HyperClickPathResolver(v,
+                    matched, v.file_name(),
                     self.roots, self.lang, self.settings
                 )
                 region = sublime.Region(line_range.b, line_range.b)

--- a/hyper_click_command.py
+++ b/hyper_click_command.py
@@ -29,9 +29,8 @@ class HyperClickJumpCommand(sublime_plugin.TextCommand):
         line_content = v.substr(line_range).strip()
         matched = self.is_valid_line(line_content)
         if matched:
-            destination_str = matched.group(1)
-            file_path = HyperClickPathResolver(
-                destination_str, v.file_name(),
+            file_path = HyperClickPathResolver(v,
+                matched, v.file_name(),
                 self.roots, self.lang, self.settings
             )
             resolved_path = file_path.resolve()


### PR DESCRIPTION
Hi other than adding support for jstl, i make a small refactoring about the regex match passed to the resolver.

In my case i need to match 2 part of the same string to find the path to the file `"<([\\w-]*)\\:([\\w-]*)",` and ` "taglib *prefix ?= ?[\"'](.*)[\"'] *tagdir ?= ?[\"'](.*)[\"']"`

So i transfer the `destination_str = matched.group(1)` inside the generic resolver `str_path.group(1)`

I added the view to the parameter passed to the resolver,if you need to parse the file to find a matched region `regions = self.view.find_all(regex_str)` as i do to find the right matched path