### PR TITLE
Jump to file with super+alt+click

### DIFF
--- a/Default.sublime-mousemap
+++ b/Default.sublime-mousemap
@@ -1,0 +1,8 @@
+[
+  {
+    "button": "button1",
+    "modifiers": ["super", "alt"],
+    "command": "hyper_click_jump",
+    "press_command": "drag_select"
+  }
+]


### PR DESCRIPTION
Implements https://github.com/aziz/SublimeHyperClick/issues/32

On Mac: <kbd>cmd</kbd> + <kbd>alt</kbd> + click
On Windows: <kbd>ctrl</kbd> + <kbd>alt</kbd> + click

Clicking a line with those keys pressed jumps to the imported file.

This combination should not obstruct any default mouse behaviour.