### PR TITLE
Add `aliases` to settings

### DIFF
--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -137,6 +137,9 @@
     "html": ["node_modules", "bower_components"],
     "jstl": ["WEB-INF"]
   },
+  "aliases": {
+    "js": {}
+  },
   "lookup_paths": {
     "js": [],
     "jstl": [

--- a/hyper_click/js_path_resolver.py
+++ b/hyper_click/js_path_resolver.py
@@ -81,13 +81,12 @@ class JsPathResolver:
         return self.resolve_node_modules(self.str_path, self.current_dir)
 
     def resolve_from_alias (self, alias, alias_source):
-        print('resolve from alias', alias, alias_source)
         if (self.str_path == alias):
             result = self.resolve_relative_to_dir(self.str_path, self.currentRoot)
             if result:
                 return result
         elif (self.str_path.startswith(alias + '/')):
-            alias_path = alias_source + self.str_path[len(alias):]
+            alias_path = path.join(alias_source, self.str_path[len(alias):])
             result = self.resolve_relative_to_dir(alias_path, self.currentRoot)
             if result:
                 return result


### PR DESCRIPTION
A bit of a long shot, but I think this might be helpful for reference even if it doesn't get merged :smile:

This adds a new setting `aliases` for the plugin, which allows you to specify path aliases e.g. for webpack or babel aliases. Main reason for a seperate setting is that aliases not necessarily have the same name as the real directory they are pointing to, so lookup folder settings etc. don't work a lot of the time.

So this PR adds the following:

```json
{
  "aliases": {
    "js": {
      "@components": "./src/components"
    }
  }
}
```

The js resolver will check if the import starts with any of the defined aliases first and will replace it with the given source path.

This PR kind of addresses a few issues (https://github.com/aziz/SublimeHyperClick/issues/36, https://github.com/aziz/SublimeHyperClick/issues/15, https://github.com/aziz/SublimeHyperClick/issues/5), but it doesn't really solve the core problem. It only allows you to define global aliases (which works for me cause I usually have the same in all my project), but ideally you should be able to define these per project + be able to pull them in from other configs e.g. in the package json. However here we run into the usual issue that there are a bazillion ways to define aliases (at least for JS bundlers) + I don't know how to read out configs from other files in python in a performant manner 😅 

