### PR TITLE
Added typescript support by default for js resolver

### DIFF
--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -8,7 +8,9 @@
       "JavaScript.tmLanguage",
       "naomi.fjsx15.sublime-syntax",
       "naomi.jsx1.sublime-syntax",
-      "Vue Component.sublime-syntax"
+      "Vue Component.sublime-syntax",
+      "TypeScript.tmLanguage",
+      "TypeScriptReact.tmLanguage"
     ],
     "sass": [
       "SCSS.tmLanguage",
@@ -122,7 +124,7 @@
     ]
   },
   "valid_extensions": {
-    "js": ["js", "jsx", "vue", "mjs"],
+    "js": ["js", "jsx", "vue", "mjs", "ts", "tsx"],
     "sass": ["scss", "sass"],
     "less": ["less"],
     "php": ["php"],

--- a/hyper_click_annotator.py
+++ b/hyper_click_annotator.py
@@ -110,6 +110,7 @@ if ST3118:
                         sublime.LAYOUT_INLINE, self.on_navigate
                     )
             else:
+                self.current_line = (-1, -1)
                 v.erase_phantoms('hyper_click')
 
         # ---------------------------------------


### PR DESCRIPTION
SublimeHyperClick do support typescript out of the box, but it requires custom configuration.
This PR eliminates this burden by including TypeScript language support by default for js resolver.

Also fixed annotation for valid imports/requires after click on not-matched line.

Fixes #40 