### PR TITLE
Fix Sass path resolution

### DIFF
--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -13,6 +13,8 @@
       "TypeScriptReact.tmLanguage"
     ],
     "sass": [
+      "SCSS.sublime-syntax",
+      "Sass.sublime-syntax",
       "SCSS.tmLanguage",
       "Sass.tmLanguage"
     ],


### PR DESCRIPTION
The previous _tmLanguage_-based Sass syntax package has been replaced with an improved [_sublime-syntax_ version](https://github.com/braver/SublimeSass).

SCSS paths were defaulting to the generic resolver