### PR TITLE
Add basic Svelte support

### DIFF
--- a/hyper_click.sublime-settings
+++ b/hyper_click.sublime-settings
@@ -10,7 +10,8 @@
       "naomi.jsx1.sublime-syntax",
       "Vue Component.sublime-syntax",
       "TypeScript.tmLanguage",
-      "TypeScriptReact.tmLanguage"
+      "TypeScriptReact.tmLanguage",
+      "Svelte.sublime-syntax"
     ],
     "sass": [
       "SCSS.sublime-syntax",
@@ -126,7 +127,7 @@
     ]
   },
   "valid_extensions": {
-    "js": ["js", "jsx", "vue", "mjs", "ts", "tsx"],
+    "js": ["js", "jsx", "vue", "mjs", "ts", "tsx", "svelte"],
     "sass": ["scss", "sass"],
     "less": ["less"],
     "php": ["php"],


### PR DESCRIPTION
This lets HyperClick annotate imports/requires inside the script blocks of [_.svelte_](https://github.com/sveltejs/svelte) files.

This is the same behavior as with [.vue](https://github.com/vuejs/vue) files.