### PR TITLE
Remove unnecessary disk IO (file existence checks) when resolving aliases

### DIFF
--- a/hyper_click/js_path_resolver.py
+++ b/hyper_click/js_path_resolver.py
@@ -45,13 +45,10 @@ class JsPathResolver:
         self.roots = roots
         self.valid_extensions = settings.get('valid_extensions', {})[lang]
         self.proj_settings = proj_settings
-        self.vendor_dirs = settings.get('vendor_dirs', {})[lang];
-
-        self.aliases = settings.get('aliases', {}).get(lang, {})
+        self.vendor_dirs = settings.get('vendor_dirs', {})[lang]
         self.proj_aliases = proj_settings.get('aliases', {}).get(lang, {})
-        for alias in self.proj_aliases:
-            self.aliases[alias] = self.proj_aliases[alias]
-
+        self.aliases = settings.get('aliases', {}).get(lang, {})
+        self.aliases.update(self.proj_aliases)
         self.matchingRoots = [root for root in self.roots if self.current_dir.startswith(root)]
         self.currentRoot = self.matchingRoots[0] if self.matchingRoots else self.current_dir
         self.lookup_paths = self.proj_settings.get('lookup_paths', {}).get(lang, False) or settings.get('lookup_paths', {}).get(lang, False) or []

--- a/hyper_click/js_path_resolver.py
+++ b/hyper_click/js_path_resolver.py
@@ -82,12 +82,14 @@ class JsPathResolver:
         # Node modules
         return self.resolve_node_modules(self.str_path, self.current_dir)
 
-    def resolve_from_alias (self, alias, alias_source):
-        alias_path = path.join(alias_source, self.str_path[len(alias) + 1:])
-        result = self.resolve_relative_to_dir(alias_path, self.currentRoot)
-        if result:
-            return result
-    
+    def resolve_from_alias(self, alias, alias_source):
+        path_parts = path.normpath(self.str_path).split(path.sep)
+
+        if path_parts[0] == alias:
+            path_parts[0] = alias_source
+
+            return self.resolve_relative_to_dir(path.join(*path_parts), self.currentRoot)
+
     def resolve_relative_to_dir(self, target, directory):
         combined = path.realpath(path.join(directory, target))
         return self.resolve_as_file(combined) or self.resolve_as_directory(combined)

--- a/hyper_click/sass_path_resolver.py
+++ b/hyper_click/sass_path_resolver.py
@@ -11,12 +11,9 @@ class SassPathResolver:
         self.roots = roots
         self.valid_extensions = settings.get('valid_extensions', {})[lang]
         self.proj_settings = proj_settings
-
-        self.aliases = settings.get('aliases', {}).get(lang, {})
         self.proj_aliases = proj_settings.get('aliases', {}).get(lang, {})
-        for alias in self.proj_aliases:
-            self.aliases[alias] = self.proj_aliases[alias]
-
+        self.aliases = settings.get('aliases', {}).get(lang, {})
+        self.aliases.update(self.proj_aliases)
         self.matchingRoots = [root for root in self.roots if self.current_dir.startswith(root)]
         self.currentRoot = self.matchingRoots[0] if self.matchingRoots else self.current_dir
         self.lookup_paths = self.proj_settings.get('lookup_paths', {}).get(lang, False) or settings.get('lookup_paths', {}).get(lang, False) or []

--- a/hyper_click/sass_path_resolver.py
+++ b/hyper_click/sass_path_resolver.py
@@ -35,10 +35,12 @@ class SassPathResolver:
         return ''
 
     def resolve_from_alias(self, alias, alias_source):
-        alias_path = path.join(alias_source, self.str_path[len(alias) + 1:])
-        result = self.resolve_relative_to_dir(alias_path, self.currentRoot)
-        if result:
-            return result
+        path_parts = path.normpath(self.str_path).split(path.sep)
+
+        if path_parts[0] == alias:
+            path_parts[0] = alias_source
+
+            return self.resolve_relative_to_dir(path.join(*path_parts), self.currentRoot)
 
     def resolve_relative_to_dir(self, target, directory):
         combined = path.realpath(path.join(directory, target))


### PR DESCRIPTION
- `alias_path = path.join(alias_source, self.str_path[len(alias) + 1:])` doen't looks robust enough.
- Calling `self.resolve_relative_to_dir()` will check a certain path is a file or not.

This PR remove unnecessary file existence checks.