### PR TITLE
Proposal for cleaner menu entries

### DIFF
--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,6 +1,6 @@
 [
     {
-        "caption": "Jump To Source File",
+        "caption": "Goto File",
         "command": "hyper_click_jump",
     }
 ]

--- a/Context.sublime-menu
+++ b/Context.sublime-menu
@@ -1,8 +1,6 @@
 [
-    { "caption": "-" },
     {
-        "caption": "Jump To Source File ➜",
+        "caption": "Jump To Source File",
         "command": "hyper_click_jump",
-    },
-    { "caption": "-"}
+    }
 ]

--- a/hyper_click.sublime-commands
+++ b/hyper_click.sublime-commands
@@ -1,3 +1,3 @@
 [
-  { "caption": "Hyper Click: Goto File", "command": "hyper_click_jump" },
+  { "caption": "HyperClick: Goto File", "command": "hyper_click_jump" },
 ]

--- a/hyper_click.sublime-commands
+++ b/hyper_click.sublime-commands
@@ -1,3 +1,3 @@
 [
-  { "caption": "Hyper Click: Jump To Source File", "command": "hyper_click_jump" },
+  { "caption": "Hyper Click: Goto File", "command": "hyper_click_jump" },
 ]


### PR DESCRIPTION
This is merely a suggestion, please feel free to do whatever. 

- "Goto File" is short, to the point, and mirrors "Goto Definition, signaling that it it similar in behavior. 
- Context menus should not have icons: it's cute but not functional. No command in there is more important than another and commands should not try to attract attention as that creates clutter. Also the icon character isn't kept in sync with the settings for the inline phantom. 
- The separators are not necessary, and it's also not really necessary for this single command to sit apart from others. 