### PR TITLE
refactor: use list-of-strings style "selectors"

### DIFF
--- a/HyperClick.sublime-settings
+++ b/HyperClick.sublime-settings
@@ -4,8 +4,27 @@
     "annotation_not_found_text": "×",
     "annotations_enabled": true,
 
-    // HyperClick is enabled when the current scope matches this selector
-    "selector": "source.js,source.ts,source.sass,source.scss,source.less,embedding.php,source.stylus,text.html,source.jstl,source.css,text.pug,source.sugarss,text.sugarml,source.nunjucks,source.jinja2,text.html.twig,source.dart,text.html.smarty",
+    // HyperClick is enabled when the current scope matches any of selectors
+    "selectors": [
+        "embedding.php",
+        "source.css",
+        "source.dart",
+        "source.jinja2",
+        "source.js",
+        "source.jstl",
+        "source.less",
+        "source.nunjucks",
+        "source.sass",
+        "source.scss",
+        "source.stylus",
+        "source.sugarss",
+        "source.ts",
+        "text.html",
+        "text.html.smarty",
+        "text.html.twig",
+        "text.pug",
+        "text.sugarml",
+    ],
 
     // Supported languages
     // - each has at least a regex to match import statements

--- a/hyper_click_command.py
+++ b/hyper_click_command.py
@@ -71,7 +71,13 @@ class HyperClickJumpCommand(sublime_plugin.TextCommand):
 
     def is_visible(self, event=None):
         view = self.view
+
+        # old style discouraged single-string selector
         selector = self.settings.get('selector')
+        if not selector:
+            # new style list of strings selectors
+            selector = "(" + ")|(".join(self.settings.get('selectors')) + ")"
+
         if not view.match_selector(view.sel()[0].a, selector):
             return False
         else:


### PR DESCRIPTION
The "selector" setting in v2 is a very long single-line string. That makes is unreadable and diff-unfriendly.

This PR proposes to make it into a list of selectors.