### PR TITLE
fix: fix alias path with up-level references resolve issue

### DIFF
--- a/hyper_click/generic_path_resolver.py
+++ b/hyper_click/generic_path_resolver.py
@@ -185,12 +185,11 @@ class GenericPathResolver:
                 return result
 
     def resolve_from_alias(self, alias, alias_source):
-        path_parts = path.normpath(self.str_path).split(path.sep)
+        path_parts = self.str_path.split(path.sep)
 
         if path_parts[0] == alias:
             path_parts[0] = alias_source
-
-            return self.resolve_relative_to_dir(path.join(*path_parts), self.current_root)
+            return self.resolve_relative_to_dir(path.normpath(path.join(*path_parts)), self.current_root)
 
     def resolve_with_exts(self, path_name):
         # matching ../index to /index.js


### PR DESCRIPTION
use case:
let's say we have some files looks like that:
```
├── api
│   └── a.js
├── src
│   ├── b.js
```

and set alias: `{"@": "./src"}`

```js
// in b.js
import a from "@/../api/a"; // this path will be correctly resolved, now
```

as i know, alias mostly use as a first level directory or as a full file path, almost never see a alias appear on middle of path.