### PR TITLE
fix: startup exception due to no selection

### DIFF
--- a/hyper_click_annotator.py
+++ b/hyper_click_annotator.py
@@ -11,6 +11,8 @@ class HyperClickAnnotator(sublime_plugin.EventListener):
         self.current_line = (-1, -1)
 
     def is_valid_line(self, line_content, view):
+        if not self.has_valid_selection(view):
+            return False
         settings = sublime.load_settings('HyperClick.sublime-settings')
         scopes = settings.get('scopes', {})
         for selector in scopes:
@@ -109,6 +111,8 @@ class HyperClickAnnotator(sublime_plugin.EventListener):
 
     def on_query_context(self, view, key, operator, operand, match_all):
         if key == 'hyper_click_jump_line':
+            if not self.has_valid_selection(view):
+                return False
             cursor = view.sel()[0].b
             line_range = view.line(cursor)
             line_content = view.substr(line_range).strip()
@@ -117,6 +121,10 @@ class HyperClickAnnotator(sublime_plugin.EventListener):
 
     def on_hover(self, view, point, hover_zone):
         self.annotate(point, view)
+
+    @staticmethod
+    def has_valid_selection(view):
+        return len(view.sel()) > 0
 
 
 def plugin_loaded():


### PR DESCRIPTION
Hopefully fix the following occasionally exception during startup.

```
Traceback (most recent call last):
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 944, in on_activated_async
    run_view_callbacks('on_activated_async', view_id)
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 708, in run_view_callbacks
    callback(v, *args)
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 190, in exception_handler
    return event_handler(*args)
  File "C:\Users\User\AppData\Roaming\Sublime Text\Installed Packages\HyperClick.sublime-package\hyper_click_annotator.py", line 105, in on_activated_async
    self.on_selection_modified_async(view)
  File "C:\Program Files\Sublime Text\Lib\python33\sublime_plugin.py", line 190, in exception_handler
    return event_handler(*args)
  File "C:\Users\User\AppData\Roaming\Sublime Text\Installed Packages\HyperClick.sublime-package\hyper_click_annotator.py", line 102, in on_selection_modified_async
    self.annotate(point, view)
  File "C:\Users\User\AppData\Roaming\Sublime Text\Installed Packages\HyperClick.sublime-package\hyper_click_annotator.py", line 49, in annotate
    matched = self.is_valid_line(line_content, view)
  File "C:\Users\User\AppData\Roaming\Sublime Text\Installed Packages\HyperClick.sublime-package\hyper_click_annotator.py", line 17, in is_valid_line
    if view.match_selector(view.sel()[0].b, selector):
  File "C:\Program Files\Sublime Text\Lib\python33\sublime.py", line 1044, in __getitem__
    raise IndexError()
IndexError
```