### PR TITLE
fix: fix alias path with up-level references resolve issue

### DIFF
--- a/hyper_click/generic_path_resolver.py
+++ b/hyper_click/generic_path_resolver.py
@@ -193,9 +193,8 @@ class GenericPathResolver:
         path_parts = re.split(r"[/\\]+", self.str_path)
 
         if path_parts[0] == alias:
-            path_parts[0] = alias_source
-            unaliased_path = path.normpath(path.join(*path_parts))
-            return self.resolve_relative_to_dir(unaliased_path, self.current_root)
+            unaliased_path = path.join(alias_source, *path_parts[1:])
+            return self.resolve_relative_to_dir(path.normpath(unaliased_path), self.current_root)
 
     def resolve_with_exts(self, path_name):
         # matching ../index to /index.js

--- a/hyper_click/generic_path_resolver.py
+++ b/hyper_click/generic_path_resolver.py
@@ -1,5 +1,6 @@
 from os import path
 import json
+import re
 
 NODE_CORE_MODULES = {
     'assert',
@@ -189,11 +190,12 @@ class GenericPathResolver:
                 return result
 
     def resolve_from_alias(self, alias, alias_source):
-        path_parts = self.str_path.split(path.sep)
+        path_parts = re.split(r"[/\\]+", self.str_path)
 
         if path_parts[0] == alias:
             path_parts[0] = alias_source
-            return self.resolve_relative_to_dir(path.normpath(path.join(*path_parts)), self.current_root)
+            unaliased_path = path.normpath(path.join(*path_parts))
+            return self.resolve_relative_to_dir(unaliased_path, self.current_root)
 
     def resolve_with_exts(self, path_name):
         # matching ../index to /index.js


### PR DESCRIPTION
This is another attempt to implement #84 and closes #91.

---

The implementation issue in the original PR is 
```py
path_parts = self.str_path.split(path.sep)
```
won't split on Windows, whose `path.sep` is `\`, while people use `/` as the separator in the import path (`self.str_path`). And thus the followed `if path_parts[0] == alias:` never be `True` because `path_parts[0]` is identical to `self.str_path`.

This PR treats both `\` and `/` as path separators while spliting.